### PR TITLE
fix(proxy): Ensure Authorization header is handled correctly

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -127,7 +127,7 @@
 
             const uploadResponse = await fetch('/.netlify/functions/upload-file-proxy', {
                 method: 'POST',
-                headers: { 'Authorization': `Bearer ${adminToken}` },
+                headers: { 'Authorization': `Bearer ${adminToken}`, 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     course_id: courseId,
                     file_name: sanitizedFileName,

--- a/netlify/functions/upload-file-proxy.js
+++ b/netlify/functions/upload-file-proxy.js
@@ -7,7 +7,13 @@ exports.handler = async (event) => {
         // First, verify the user is an admin, as this function has elevated privileges.
         // We can't use the service key for this, we must use the anon key and the user's token.
         const anonSupabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_ANON_KEY);
-        const token = event.headers.authorization.split(' ')[1];
+
+        const authHeader = event.headers.authorization;
+        if (!authHeader) {
+            throw new Error('Authorization header is missing.');
+        }
+        const token = authHeader.split(' ')[1];
+
         const { data: { user }, error: authError } = await anonSupabase.auth.getUser(token);
 
         if (authError || !user || user.email.toLowerCase() !== 'admin@cic.kz') {


### PR DESCRIPTION
This commit resolves a `TypeError` in the `upload-file-proxy.js` function that occurred when the `event.headers.authorization` was undefined.

Changes:
- In `admin.html`, the `fetch` call to the proxy uploader now explicitly includes the `'Content-Type': 'application/json'` header. This ensures the request is well-formed and should prevent proxying issues that might strip the `Authorization` header.
- In `upload-file-proxy.js`, a guard clause has been added to check for the existence of the `Authorization` header before it is used. If the header is missing, a clear error is thrown.

These changes make the proxy upload mechanism more robust and should prevent the reported crash.