### PR TITLE
Fix: Improve error logging for publish action

### DIFF
--- a/netlify/functions/admin-handler.js
+++ b/netlify/functions/admin-handler.js
@@ -140,6 +140,13 @@ exports.handler = async (event) => {
         return { statusCode: 200, body: JSON.stringify(result) };
     } catch (error) {
         console.error('Error in admin-handler:', JSON.stringify(error, null, 2));
-        return { statusCode: 500, body: JSON.stringify({ error: error.message }) };
+        // Provide more detailed error messages to the client for easier debugging
+        const errorMessage = {
+            message: error.message,
+            details: error.details,
+            hint: error.hint,
+            code: error.code,
+        };
+        return { statusCode: 500, body: JSON.stringify({ error: errorMessage }) };
     }
 };


### PR DESCRIPTION
This commit enhances the error handling in the main `admin-handler` function.

Previously, any error caught during the execution would return a generic message (`error.message`). This change modifies the `catch` block to return a more detailed error object, including the `details`, `hint`, and `code` properties from the Supabase error object.

This is intended to help diagnose a `500 Internal Server Error` that is occurring when the 'publish_course' action is called. By exposing more detailed error information to the client, we can better understand why the database update is failing.