### PR TITLE
I'm reverting the change that updated the Gemini model to '2.0-flash'…

### DIFF
--- a/netlify/functions/admin-handler.js
+++ b/netlify/functions/admin-handler.js
@@ -6,7 +6,7 @@ const pdf = require('pdf-parse');
 // Initialize Supabase and Gemini AI
 const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash' });
+const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
 
 async function uploadAndProcessFile(payload) {
     const { course_id, title, file_name, file_data } = payload;


### PR DESCRIPTION
… and setting it back to `gemini-1.5-flash`.

The '2.0-flash' model was also unavailable and did not resolve the content generation errors.

I've determined that the existing retry logic in the `generateContent` function is the correct way to handle the transient `503 Service Unavailable` errors from the API. Therefore, I'm reverting to the stable model name and will rely on that mechanism.