### PR TITLE
Fix: Restore and increase function timeout to 60s

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,6 @@
 
 [functions."*"]
   node_version = 18
+
+[functions."admin-handler"]
+  timeout = 60


### PR DESCRIPTION
This commit re-introduces a timeout for the `admin-handler` function, setting it to 60 seconds.

This is necessary because the AI content generation step (`generateContent`) is a long-running process that was failing under the default 10-second timeout. This failure manifested as a JSON parsing error on the frontend (`Unexpected end of JSON input`) because the server connection was being terminated prematurely.

The timeout was removed in a previous commit under the mistaken assumption it was no longer needed. This change restores it to ensure the stability of the AI generation feature.