### PR TITLE
Fix: Improve server-side error logging in admin-handler

### DIFF
--- a/netlify/functions/admin-handler.js
+++ b/netlify/functions/admin-handler.js
@@ -140,7 +140,7 @@ exports.handler = async (event) => {
 
         return { statusCode: 200, body: JSON.stringify(result) };
     } catch (error) {
-        console.error('Error in admin-handler:', JSON.stringify(error, null, 2));
+        console.error('Error in admin-handler:', error); // Log the full error object
         // Provide more detailed error messages to the client for easier debugging
         const errorMessage = {
             message: error.message,


### PR DESCRIPTION
This commit improves the error logging within the main `catch` block of the `admin-handler` function.

The previous implementation used `console.error(JSON.stringify(error))`, which produced unhelpful empty objects (`{}`) in the logs because standard Error object properties are non-enumerable.

This has been changed to `console.error(error)`, which will log the full, detailed error object to the console, providing much better information for any future debugging.