### PR TITLE
Fix(DB): Correct data handling in admin-save-course.js

### DIFF
--- a/netlify/functions/admin-save-course.js
+++ b/netlify/functions/admin-save-course.js
@@ -11,14 +11,16 @@ exports.handler = async (event) => {
             return { statusCode: 400, body: JSON.stringify({ error: 'Необходимы все поля для сохранения.' }) };
         }
 
+        const courseContent = {
+            summary: content_html,
+            questions: questions
+        };
+
         const { data, error } = await supabase
             .from('courses')
             .update({
-                content_html: content_html,
-                questions: questions,
+                content_html: courseContent,
                 status: status, // 'draft' или 'published'
-                admin_prompt: admin_prompt,
-                last_updated: new Date().toISOString()
             })
             .eq('course_id', course_id);
 


### PR DESCRIPTION
This commit resolves the persistent 500 error that occurred during course publication. The root cause was identified in `netlify/functions/admin-save-course.js`, which was attempting to write to several non-existent columns in the `courses` table (`questions`, `admin_prompt`, `last_updated`).

The fix implements the following changes:
- The `questions` data is now merged with the `content_html` data into a single JSON object before saving.
- This combined object is stored in the `content_html` column.
- The direct update attempts to the non-existent columns have been removed, which resolves the `PGRST204` error.