### PR TITLE
fix(admin): ensure product_line is updated on publish

### DIFF
--- a/netlify/functions/admin-handler.js
+++ b/netlify/functions/admin-handler.js
@@ -140,12 +140,18 @@ async function textToSpeech(supabase, payload) {
 }
 
 async function publishCourse(supabase, payload) {
-    const { course_id, content_html, questions, admin_prompt } = payload;
+    const { course_id, content_html, questions, admin_prompt, product_line } = payload;
     const courseContent = { summary: content_html, questions: questions, admin_prompt: admin_prompt || '' };
-    const { error } = await supabase.from('courses').update({
+    const updateData = {
         content_html: courseContent,
         status: 'published'
-    }).eq('course_id', course_id);
+    };
+
+    if (product_line) {
+        updateData.product_line = product_line;
+    }
+
+    const { error } = await supabase.from('courses').update(updateData).eq('course_id', course_id);
     if (error) throw error;
     return { message: `Course ${course_id} successfully published.` };
 }


### PR DESCRIPTION
The publishCourse function was not including the `product_line` in the database update payload, causing this field to be ignored when a course was published.

This commit fixes the issue by adding the `product_line` to the update object if it exists in the payload.

A new test case has been added to verify that the `product_line` is correctly passed to the database update function. Existing tests that were failing due to incorrect assertions or mock setups have also been fixed.