### PR TITLE
fix: Resolve multiple 500 errors and improve DB performance

### DIFF
--- a/migrations/021_fix_user_progress_pk.sql
+++ b/migrations/021_fix_user_progress_pk.sql
@@ -1,0 +1,28 @@
+-- Step 1: Add the new user_id column (nullable for now)
+ALTER TABLE public.user_progress ADD COLUMN user_id UUID;
+
+-- Step 2: Populate the new user_id from the auth.users table
+-- This assumes that every email in user_progress exists in auth.users
+UPDATE public.user_progress
+SET user_id = (SELECT id FROM auth.users WHERE auth.users.email = public.user_progress.user_email)
+WHERE user_id IS NULL;
+
+-- Step 3: Drop the old primary key
+-- The name of the constraint might be different, check with \d user_progress in psql
+-- Common default name is user_progress_pkey
+ALTER TABLE public.user_progress DROP CONSTRAINT IF EXISTS user_progress_pkey;
+
+-- Step 4: Make user_id NOT NULL now that it's populated
+ALTER TABLE public.user_progress ALTER COLUMN user_id SET NOT NULL;
+
+-- Step 5: Create the new composite primary key
+ALTER TABLE public.user_progress ADD PRIMARY KEY (user_id, course_id);
+
+-- Step 6: Create an index on user_email for potential lookups if still needed
+CREATE INDEX IF NOT EXISTS idx_user_progress_user_email ON public.user_progress(user_email);
+
+-- Optional: To keep user_email in sync with auth.users, you could implement a trigger.
+-- For now, we assume the application logic will handle this.
+
+COMMENT ON COLUMN public.user_progress.user_id IS 'Foreign key to auth.users.id. Part of the new composite primary key.';
+COMMENT ON COLUMN public.user_progress.user_email IS 'Email of the user. Kept for convenience but no longer part of the primary key.';

--- a/migrations/022_fix_detailed_report_rpc_again.sql
+++ b/migrations/022_fix_detailed_report_rpc_again.sql
@@ -1,0 +1,41 @@
+-- Миграция для исправления отчета get_detailed_report_data
+-- Причина: Фильтр по department падал, если у пользователя не было профиля (prof.department IS NULL).
+-- Решение: Использовать COALESCE для замены NULL на пустую строку перед фильтрацией.
+
+CREATE OR REPLACE FUNCTION get_detailed_report_data(
+    user_email_filter TEXT DEFAULT NULL,
+    department_filter TEXT DEFAULT NULL,
+    course_id_filter TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    user_email TEXT,
+    percentage INT,
+    completed_at TIMESTAMPTZ,
+    time_spent_seconds INT,
+    courses JSON,
+    user_profiles JSON
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        up.user_email,
+        up.percentage,
+        up.completed_at,
+        up.time_spent_seconds,
+        json_build_object('title', c.title) as courses,
+        json_build_object('full_name', prof.full_name, 'department', prof.department) as user_profiles
+    FROM
+        public.user_progress up
+    LEFT JOIN
+        public.courses c ON up.course_id = c.course_id
+    LEFT JOIN
+        auth.users u ON up.user_email = u.email
+    LEFT JOIN
+        public.user_profiles prof ON u.id = prof.id
+    WHERE
+        (user_email_filter IS NULL OR up.user_email ILIKE ('%' || user_email_filter || '%')) AND
+        -- Fix: Use COALESCE to prevent error when department is NULL
+        (department_filter IS NULL OR COALESCE(prof.department, '') ILIKE ('%' || department_filter || '%')) AND
+        (course_id_filter IS NULL OR up.course_id = course_id_filter);
+END;
+$$ LANGUAGE plpgsql;

--- a/migrations/023_refactor_leaderboard_rpc.sql
+++ b/migrations/023_refactor_leaderboard_rpc.sql
@@ -1,0 +1,46 @@
+-- Миграция для рефакторинга и повышения надежности RPC функции get_weekly_leaderboard
+-- Причина: Усложненный ORDER BY может вызывать проблемы с NULL значениями.
+-- Решение: Добавить COALESCE в ORDER BY для безопасной сортировки.
+
+CREATE OR REPLACE FUNCTION get_weekly_leaderboard(p_order_by TEXT)
+RETURNS TABLE (
+    full_name TEXT,
+    user_email TEXT,
+    courses_completed BIGINT,
+    total_time_spent_minutes BIGINT,
+    average_score NUMERIC
+) AS $$
+BEGIN
+    RETURN QUERY
+    WITH weekly_progress AS (
+        SELECT
+            p.user_email,
+            -- Ensure counts and sums are not null
+            COALESCE(COUNT(CASE WHEN p.percentage = 100 THEN 1 END), 0) as courses_completed_count,
+            COALESCE(SUM(p.time_spent_seconds), 0) as total_seconds,
+            AVG(CASE WHEN p.percentage > 0 THEN p.percentage ELSE NULL END) as avg_score_val
+        FROM public.user_progress p
+        WHERE
+            p.updated_at >= now() - interval '7 days'
+        GROUP BY p.user_email
+    )
+    SELECT
+        COALESCE(up.full_name, wp.user_email) AS full_name,
+        wp.user_email,
+        wp.courses_completed_count AS courses_completed,
+        (wp.total_seconds / 60) AS total_time_spent_minutes,
+        ROUND(COALESCE(wp.avg_score_val, 0), 2) AS average_score
+    FROM weekly_progress wp
+    LEFT JOIN auth.users u ON wp.user_email = u.email
+    LEFT JOIN public.user_profiles up ON u.id = up.id
+    ORDER BY
+        CASE
+            -- Use COALESCE to handle potential NULLs gracefully during sorting
+            WHEN p_order_by = 'courses_completed' THEN COALESCE(wp.courses_completed_count, 0)
+            WHEN p_order_by = 'time_spent' THEN COALESCE(wp.total_seconds, 0)
+            WHEN p_order_by = 'avg_score' THEN COALESCE(wp.avg_score_val, 0)
+            ELSE COALESCE(wp.courses_completed_count, 0)
+        END DESC NULLS LAST
+    LIMIT 10;
+END;
+$$ LANGUAGE plpgsql;

--- a/migrations/024_create_get_sim_results_rpc.sql
+++ b/migrations/024_create_get_sim_results_rpc.sql
@@ -1,0 +1,36 @@
+-- Миграция для создания RPC функции для получения результатов симуляции с данными пользователя
+-- Причина: Текущая реализация делает 3 отдельных запроса, что неэффективно.
+-- Решение: Создать единую функцию, которая объединяет данные на стороне БД.
+
+CREATE OR REPLACE FUNCTION get_simulation_results_with_user_data()
+RETURNS TABLE (
+    id INT,
+    user_id UUID,
+    scenario TEXT,
+    persona TEXT,
+    evaluation JSONB,
+    created_at TIMESTAMPTZ,
+    user_email TEXT,
+    full_name TEXT
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        ds.id,
+        ds.user_id,
+        ds.scenario,
+        ds.persona,
+        ds.evaluation,
+        ds.created_at,
+        u.email as user_email,
+        COALESCE(p.full_name, u.email) as full_name
+    FROM
+        public.dialogue_simulations ds
+    LEFT JOIN
+        auth.users u ON ds.user_id = u.id
+    LEFT JOIN
+        public.user_profiles p ON ds.user_id = p.id
+    ORDER BY
+        ds.created_at DESC;
+END;
+$$ LANGUAGE plpgsql;

--- a/migrations/025_create_get_users_rpc.sql
+++ b/migrations/025_create_get_users_rpc.sql
@@ -1,0 +1,26 @@
+-- Миграция для создания RPC функции для получения всех пользователей с их профилями
+-- Причина: Вложенный select в Supabase может быть хрупким.
+-- Решение: Заменить его на явный LEFT JOIN внутри RPC функции для большей надежности.
+
+CREATE OR REPLACE FUNCTION get_all_users_with_profiles()
+RETURNS TABLE (
+    id UUID,
+    email TEXT,
+    full_name TEXT,
+    department TEXT
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        u.id,
+        u.email,
+        COALESCE(p.full_name, u.raw_user_meta_data->>'full_name', 'N/A') as full_name,
+        COALESCE(p.department, 'N/A') as department
+    FROM
+        auth.users u
+    LEFT JOIN
+        public.user_profiles p ON u.id = p.id
+    WHERE
+        u.role = 'authenticated'; -- or whatever role your users have
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
This commit addresses multiple 500 Internal Server Errors across the application by refactoring database interactions to be more robust and efficient.

Key changes:
- Chore(user_progress): Changed the primary key of the `user_progress` table from `(user_email, course_id)` to `(user_id, course_id)` for better data integrity. Created a migration to handle this change.
- Fix(assign-course): Updated the `assign-course` function to use the new primary key structure, resolving the 500 error on course self-assignment.
- Perf(admin-handler): Replaced inefficient client-side data joining in `admin-handler.js` with new, robust RPC functions for `get_simulation_results` and `get_all_users`.
- Fix(reports): Corrected the `get_detailed_report_data` RPC to handle `NULL` values in department filters, preventing query failures.
- Fix(leaderboard): Refactored the `get_weekly_leaderboard` RPC to handle `NULL` values in aggregated data, making the leaderboard more reliable.
- Test: Updated unit tests to reflect the new RPC-based implementation and ensure all tests pass.