### PR TITLE
Fix JSON parsing for AI-generated content

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -828,7 +828,7 @@ async function handleGenerateContent(jobId, payload, token) {
         console.log(`[Job ${jobId}] Generating content with Gemini...`);
         const result = await model.generateContent(finalPrompt);
         const response = await result.response;
-        const jsonString = response.text().replace(/\\`\\`\\`json/g, '').replace(/\\`\\`\\`/g, '').trim();
+        const jsonString = response.text().replace(/```json\n|```/g, '').trim();
 
         let parsedJson;
         try {


### PR DESCRIPTION
The `handleGenerateContent` background job was failing because the AI model returns a JSON string wrapped in a markdown code block (```json).

The previous regex was incorrect and failed to strip the markdown fences, leading to a `SyntaxError` when `JSON.parse()` was called.

This commit replaces the faulty regex with a correct one that properly removes the markdown wrapper before parsing, making the content generation process robust to this AI model behavior.