### PR TITLE
Fix: Correct course assignment and UI refresh logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -1109,7 +1109,9 @@
                         body: JSON.stringify({ course_id: courseId })
                     });
                     alert('Вы успешно записаны на курс! Он появится в ваших назначенных курсах.');
-                    // Switch to the "Assigned" tab and re-render the view
+                    // Re-fetch all course data to ensure the UI is up-to-date
+                    await showMainMenu();
+                    // Then switch to the 'assigned' tab
                     document.querySelector('.tab-btn[data-filter="assigned"]').click();
                 } catch (error) {
                     console.error('Failed to assign course:', error);


### PR DESCRIPTION
This commit addresses two critical bugs in the course assignment and display flow:

1.  **Server-Side RPC Fix:**
    - Corrected the `assign_course_to_user` action in `server/index.js`.
    - The previous implementation used an invalid query syntax (`.rpc().eq()`), which caused a 500 Internal Server Error when assigning a course to a user from the admin panel.
    - The new logic correctly fetches all users via the RPC call and then filters by email in JavaScript, resolving the server error and making course assignment functional.

2.  **Client-Side UI Refresh Fix:**
    - Fixed an issue in `index.html` where a course enrolled from the catalog would not appear in the user's 'Assigned' list without a manual page refresh.
    - The click handler for the catalog's 'enroll' button now calls `showMainMenu()` to re-fetch all course data from the server, ensuring the UI updates immediately with the new course.

These two fixes work together to create a seamless and functional course assignment experience, both from the admin panel and the user-facing catalog.