### PR TITLE
Fix course content display in admin panel

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1012,6 +1012,14 @@
             let course = await apiCall(ACTIONS.GET_COURSE_DETAILS, { course_id: courseId });
             currentEditingCourseId = courseId;
 
+            // Defensively parse content if it's a stringified JSON from the DB
+            if (typeof course.content === 'string' && course.content.trim().startsWith('{')) {
+                try { course.content = JSON.parse(course.content); } catch (e) { console.warn("Could not auto-parse course.content string:", e); }
+            }
+            if (typeof course.draft_content === 'string' && course.draft_content.trim().startsWith('{')) {
+                try { course.draft_content = JSON.parse(course.draft_content); } catch (e) { console.warn("Could not auto-parse course.draft_content string:", e); }
+            }
+
             // If a published course has content but no draft, create a draft from the published content.
             // This prevents the editor from opening empty and accidentally wiping content.
             if (course.status === 'published' && course.content && !course.draft_content) {

--- a/server/index.js
+++ b/server/index.js
@@ -890,11 +890,11 @@ ${courseData.description}
             }
         }
 
-        // The 'content' column is TEXT, so we store the JSON as a string.
+        // The 'content' column is JSONB. Pass the object directly.
         console.log(`[Job ${jobId}] Content generated, now with images. Saving to database...`);
         const { error: dbError } = await supabaseAdmin
             .from('courses')
-            .update({ content: JSON.stringify(parsedContent) })
+            .update({ content: parsedContent }) // Pass the JS object directly for JSONB
             .eq('id', course_id);
 
         if (dbError) throw new Error(`Failed to save generated content: ${dbError.message}`);


### PR DESCRIPTION
This commit fixes a bug where course content was not visible in the admin editor for certain courses.

The root cause was that the generated content, which is a JSON object, was being incorrectly saved as a string in the `jsonb` database column.

The fix is two-fold:
1.  The backend content generation logic in `server/index.js` is corrected to pass the JSON object directly to the database, preventing future data corruption.
2.  The frontend logic in `admin.html` is made more robust. It now defensively parses the content field if it receives a string, ensuring that existing malformed data can still be displayed correctly.