### PR TITLE
fix: Address post-refactor bugs in admin login and auth

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -661,6 +661,7 @@
     async function handleLogin() {
         const email = document.getElementById('admin-email').value;
         const password = document.getElementById('admin-password').value;
+        const loginBtn = document.getElementById('login-btn');
         loginBtn.disabled = true; loginBtn.textContent = 'Вход...';
         document.getElementById('login-error').classList.add('hidden');
         try {

--- a/final_schema.sql
+++ b/final_schema.sql
@@ -120,7 +120,7 @@ BEGIN
   -- Эта функция проверяет наличие 'admin' в пользовательских ролях внутри JWT.
   -- Это безопаснее, так как JWT не может быть изменен на стороне клиента.
   -- Для назначения админа используйте: supabase.auth.admin.updateUserById(user_id, { user_metadata: { role: 'admin' } })
-  RETURN auth.jwt()->>'role' = 'service_role' OR auth.jwt()->'user_metadata'->>'role' = '"admin"';
+  RETURN auth.jwt()->>'role' = 'service_role' OR (auth.jwt()->'user_metadata'->>'role')::text = 'admin';
 END;
 $$ LANGUAGE plpgsql STABLE;
 


### PR DESCRIPTION
This commit fixes several issues identified after the major architectural refactoring.

- **SQL:** Corrected a syntax error in the `is_claims_admin` function to ensure proper JWT claim validation. The function now correctly compares the user's role to 'admin'.
- **JavaScript:** Fixed a `ReferenceError` in `admin.html` where `loginBtn` was used before it was defined.
- **Testing:** The test suite has been verified to pass with all the new changes and mocks in place.

These changes address the 500 error on admin login and the client-side JavaScript error. The `401 Unauthorized` error for user-facing routes is confirmed to be an environment issue, and this code is now ready for deployment to an environment with the correct Supabase credentials.