### PR TITLE
Refactor course page layout to be static with internal scrolling and …

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,36 +226,6 @@
             padding: 0;
         }
     </style>
-    <style id="jules-layout-fixes-2">
-        body, html {
-            overflow: hidden !important;
-        }
-        .window {
-            display: flex;
-            flex-direction: column;
-            height: 100%;
-            padding-top: 20px;
-            padding-bottom: 20px;
-        }
-        .window-header {
-            flex-shrink: 0;
-            margin-bottom: 20px;
-        }
-        .content-area {
-            flex-grow: 1;
-            min-height: 0;
-            height: auto !important; /* Override 60vh */
-            overflow-y: auto !important;
-        }
-        .window-footer {
-            flex-shrink: 0;
-        }
-        #grouped-courses-container {
-            display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            gap: 25px;
-        }
-    </style>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2?v=4"></script>
     <script>
         const SUPABASE_URL = 'https://wnsdlibhrlmgyszbyxat.supabase.co';
@@ -263,18 +233,18 @@
         const supabaseClient = supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
     </script>
     <style id="layout-override">
-        .main-menu {
+        #main-menu {
             grid-template-columns: repeat(2, 1fr);
             gap: 15px;
         }
-        .main-menu .menu-item {
+        #main-menu .menu-item {
             padding: 15px;
         }
-        .main-menu .menu-item h3 {
+        #main-menu .menu-item h3 {
             font-size: 1.1em;
             margin-bottom: 5px;
         }
-        .main-menu .menu-item-icon {
+        #main-menu .menu-item-icon {
             font-size: 1.2em;
             margin-right: 10px;
         }
@@ -284,7 +254,83 @@
             background: var(--surface-color);
             z-index: 10;
         }
+        #main-menu-tabs {
+            position: sticky;
+            top: 107px; /* Height of the header. May need adjustment. */
+            background: var(--surface-color);
+            z-index: 10;
+        }
     </style>
+    <style id="jules-final-fixes">
+    /* 1. Main window layout */
+    body, html {
+        overflow: hidden;
+    }
+    .window {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+    }
+    .window-header, .window-footer {
+        flex-shrink: 0;
+    }
+    .content-area {
+        flex-grow: 1;
+        min-height: 0;
+        height: auto; /* Override default height */
+        overflow: hidden; /* This container should not scroll */
+    }
+
+    /* 2. Main content flex layout */
+    #main-flex-container {
+        display: flex;
+        height: 100%;
+        gap: 20px;
+    }
+    #leaderboard-container {
+        flex: 1 1 300px;
+        min-width: 280px;
+        padding: 15px;
+        background-color: #e9f7fe;
+        border-radius: 8px;
+        align-self: flex-start;
+    }
+    #main-content-wrapper {
+        flex: 2 1 500px;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+    }
+    #main-menu-tabs {
+        flex-shrink: 0; /* Don't shrink */
+    }
+    #main-menu {
+        flex-grow: 1; /* Take remaining space */
+        overflow-y: auto;
+        min-height: 0; /* Allow scrolling */
+    }
+
+    /* 3. Two-column grid layouts */
+    #main-menu, .main-menu {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 15px;
+    }
+    #grouped-courses-container {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 25px;
+    }
+
+    /* 4. Adaptive presentation images */
+    .presentation-slide img {
+        max-width: 100%;
+        height: auto;
+        display: block;
+        margin-top: 15px;
+        border-radius: 8px;
+    }
+</style>
 </head>
 <body>
     <div id="toast-container"></div>
@@ -319,12 +365,12 @@
             </div>
             <div id="content-loader" class="hidden" style="display: flex; justify-content: center; align-items: center; height: 60vh;"><div class="loader"></div></div>
             <div class="content-area" id="content-area">
-                <div id="main-flex-container" style="display: flex; flex-wrap: wrap; gap: 20px;">
-                    <div id="leaderboard-container" style="flex: 1 1 300px; min-width: 280px; padding: 15px; background-color: #e9f7fe; border-radius: 8px; align-self: flex-start;">
+                <div id="main-flex-container">
+                    <div id="leaderboard-container">
                         <h3 style="margin-top: 0; color: var(--primary-color);">🏆 Топ Учеников Недели</h3>
                         <div id="leaderboard-content"></div>
                     </div>
-                    <div id="main-content-wrapper" style="flex: 2 1 500px;">
+                    <div id="main-content-wrapper">
                         <div id="main-menu-tabs" style="display: flex; border-bottom: 1px solid var(--border-color); margin-bottom: 15px;">
                             <button class="tab-btn active" data-filter="assigned">📥 Назначенные</button>
                             <button class="tab-btn" data-filter="completed">✅ Пройденные</button>
@@ -354,8 +400,9 @@
                     <button id="back-to-menu-from-results">Вернуться в меню</button>
                 </div>
                 <div id="simulator-view" class="hidden">
+                    <button id="back-from-simulator-btn" class="btn" style="background-color: #6c757d; margin-bottom: 20px; float: right;">‹ Назад в меню</button>
                     <div id="simulator-setup">
-                        <h3>Настройка тренажера</h3>
+                        <h3 style="clear: both;">Настройка тренажера</h3>
                         <div style="margin-bottom: 20px;">
                             <label for="disposition-slider" style="display: block; margin-bottom: 10px; font-weight: bold;">1. Выберите настроение клиента:</label>
                             <input type="range" id="disposition-slider" min="0" max="2" value="1" style="width: 100%;">
@@ -561,14 +608,6 @@
         stopTimeTracking();
         windowTitle.textContent = 'Главное Меню';
         backButtonAction = null;
-
-        const windowEl = appView.querySelector('.window');
-        const tabsEl = document.getElementById('main-menu-tabs');
-        const contentAreaEl = document.getElementById('content-area');
-        if (windowEl && tabsEl && contentAreaEl && tabsEl.parentElement !== windowEl) {
-            windowEl.insertBefore(tabsEl, contentAreaEl);
-        }
-
         productContent.classList.add('hidden');
         testView.classList.add('hidden');
         testResultsView.classList.add('hidden');
@@ -714,7 +753,7 @@
     }
     async function renderCatalog() {
         mainMenu.innerHTML = '';
-        mainMenu.style.display = 'grid';
+        mainMenu.className = 'main-menu'; // Ensure grid styles are applied
         mainMenu.innerHTML = '<div class="loader"></div>';
         try {
             const catalogCourses = await fetchAuthenticated('/api/getCourseCatalog', { method: 'POST' });
@@ -1076,6 +1115,7 @@
                 showMainMenu();
             }
         });
+        document.getElementById('back-from-simulator-btn').addEventListener('click', showMainMenu);
     });
     let currentScenario = '';
     function showSimulatorView() {


### PR DESCRIPTION
…grid.

This commit attempts to implement a new layout for the course page based on user feedback.

Key changes include:
- Refactored CSS to create a static, full-screen view where only the main course list scrolls.
- Implemented a two-column grid layout for course groups, individual courses, and the course catalog.
- Made images within the course presentation view adaptive to prevent overflow.
- Added a "Back" button to the dialogue simulator for easier navigation.

Note: This is the best effort to meet the requirements after multiple iterations and failing code reviews. The user requested this pull request to save the work for inspection.