### PR TITLE
Make presentation page responsive to prevent scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,6 +228,47 @@
                 padding: 15px;
             }
         }
+        @media (max-height: 750px) {
+            .presentation-view-right-content {
+                padding: 15px 20px;
+            }
+            .presentation-slide h2 {
+                font-size: clamp(1em, 2.2vw, 1.3em);
+            }
+            .presentation-slide {
+                font-size: clamp(0.8em, 1.8vw, 0.9em);
+            }
+            .presentation-slide img {
+                max-height: 30vh;
+                margin-bottom: 0.5rem;
+            }
+            .slider-nav-buttons {
+                padding-top: 10px;
+            }
+        }
+        @media (max-height: 650px) {
+            .presentation-view-right-content {
+                padding: 10px 15px;
+            }
+            .presentation-slide h2 {
+                font-size: clamp(0.9em, 2vw, 1.1em);
+            }
+            .presentation-slide {
+                font-size: clamp(0.7em, 1.5vw, 0.8em);
+            }
+            .presentation-slide img {
+                max-height: 25vh;
+                margin-bottom: 0.25rem;
+            }
+            .slider-nav-buttons {
+                padding-top: 5px;
+                gap: 5px;
+            }
+             .slider-nav-buttons button {
+                padding: 4px 12px;
+                font-size: 0.8em;
+            }
+        }
     </style>
     <style>
         /* Toast Notifications */


### PR DESCRIPTION
The presentation view was overflowing on shorter screens, causing a vertical scrollbar to appear. The user requested that the page be made responsive to fit the screen without scrolling.

This change introduces height-based media queries to create a more adaptive layout.

- Added a media query for screens with a max-height of 750px to reduce padding, font sizes, and image height.
- Added a second, more aggressive media query for screens with a max-height of 650px to further compact the layout on very short screens.

These changes ensure that the presentation content adjusts to different viewport heights, providing a better user experience and eliminating the need for scrolling.