### PR TITLE
feat: Adjust presentation font size to fit screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,10 +99,10 @@
             font-size: 0.85em; /* Smaller font in chat */
         }
         .presentation-slide h2 {
-            font-size: clamp(1.1em, 2.5vw, 1.5em);
+            font-size: clamp(1em, 2.2vw, 1.3em);
         }
         .presentation-slide {
-            font-size: clamp(0.85em, 2vw, 0.95em);
+            font-size: clamp(0.75em, 1.8vw, 0.85em);
         }
         .sidebar-panel {
             background: var(--surface-color);
@@ -233,10 +233,10 @@
                 padding: 15px 20px;
             }
             .presentation-slide h2 {
-                font-size: clamp(1em, 2.2vw, 1.3em);
+                font-size: clamp(0.9em, 2vw, 1.2em);
             }
             .presentation-slide {
-                font-size: clamp(0.8em, 1.8vw, 0.9em);
+                font-size: clamp(0.7em, 1.6vw, 0.8em);
             }
             .presentation-slide img {
                 max-height: 30vh;
@@ -251,10 +251,10 @@
                 padding: 10px 15px;
             }
             .presentation-slide h2 {
-                font-size: clamp(0.9em, 2vw, 1.1em);
+                font-size: clamp(0.8em, 1.8vw, 1em);
             }
             .presentation-slide {
-                font-size: clamp(0.7em, 1.5vw, 0.8em);
+                font-size: clamp(0.65em, 1.4vw, 0.75em);
             }
             .presentation-slide img {
                 max-height: 25vh;


### PR DESCRIPTION
Reduces the font size of the presentation slides to prevent vertical scrolling and ensure the content fits within the viewport.

- Modified the `clamp()` values for `.presentation-slide` and `.presentation-slide h2`.
- Adjusted font sizes in media queries for various screen heights.