### PR TITLE
feat: Implement course creation from Google Slides

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -712,6 +712,7 @@
         const courseId = isEditing ? course.id : '';
         const title = isEditing ? course.title || '' : '';
         const description = isEditing ? course.description || '' : '';
+        const presentationUrl = isEditing ? course.presentation_url || '' : '';
         const isVisible = isEditing ? course.is_visible : false;
         const headerText = isEditing ? `Редактирование: ${title}` : 'Создать новый курс';
 
@@ -735,9 +736,15 @@
                 <h2>${headerText}</h2>
                 <input type="hidden" id="course-id" value="${escapeHTML(courseId)}">
                 <input type="text" id="course-title" placeholder="Название курса" value="${escapeHTML(title)}">
-                <h3>Шаг 1: Загрузите файл для описания</h3>
+                <h3>Шаг 1А: Генерация из файла (текущий функционал)</h3>
                 <input type="file" id="file-uploader" accept=".pdf,.docx">
                 <button id="process-file-btn">Загрузить и извлечь текст</button>
+                <hr style="margin: 20px 0;">
+                <h3>ИЛИ Шаг 1Б: Генерация по ссылке на Google Slides</h3>
+                <p style="font-size: 0.9em; color: #666; margin-top: -5px;">Для корректной работы опубликуйте презентацию в интернете (Файл -> Поделиться -> Опубликовать в интернете) и вставьте ссылку сюда.</p>
+                <input type="url" id="presentation-url" placeholder="Вставьте ссылку на опубликованную Google Slides презентацию" value="${escapeHTML(presentationUrl)}">
+                <button id="process-presentation-btn">Создать/Обновить курс по презентации</button>
+                <hr style="margin: 20px 0;">
                 <h3>Описание (Источник для AI)</h3>
                 <div style="display: flex; gap: 10px; margin-bottom: 10px;">
                     <button id="text-to-speech-btn" style="flex: 1;">Озвучить описание</button>
@@ -774,6 +781,7 @@
     function attachCourseFormListeners() {
         document.getElementById('cancel-edit-btn').addEventListener('click', clearCourseForm);
         document.getElementById('process-file-btn').addEventListener('click', processFileHandler);
+        document.getElementById('process-presentation-btn').addEventListener('click', processPresentationHandler);
         document.getElementById('generate-btn').addEventListener('click', generateContentHandler);
         document.getElementById('text-to-speech-btn').addEventListener('click', textToSpeechHandler);
         document.getElementById('publish-btn').addEventListener('click', publishCourseHandler);
@@ -865,6 +873,36 @@
                 await loadCourses();
             };
         } catch(e) { /* Handled */ }
+    }
+
+    async function processPresentationHandler() {
+        const btn = document.getElementById('process-presentation-btn');
+        btn.disabled = true;
+        try {
+            const presentationUrl = document.getElementById('presentation-url').value.trim();
+            const title = document.getElementById('course-title').value.trim();
+            if (!presentationUrl || !title) {
+                showToast('Укажите название курса и ссылку на презентацию.', 'error');
+                return;
+            }
+            let courseId = document.getElementById('course-id').value.trim();
+            if (!courseId) {
+                const newCourse = await apiCall(ACTIONS.CREATE_COURSE, { title });
+                courseId = newCourse.id;
+                document.getElementById('course-id').value = courseId;
+                showToast(`Создан новый курс. ID: ${courseId}`, 'success');
+                currentEditingCourseId = courseId;
+            }
+
+            await apiCall(ACTIONS.PROCESS_PRESENTATION, { course_id: courseId, presentation_url: presentationUrl });
+            document.getElementById('description').value = 'Презентация обрабатывается... Текст появится здесь после завершения фоновой задачи.';
+            await loadCourses();
+
+        } catch(e) {
+            // handled in apiCall
+        } finally {
+            btn.disabled = false;
+        }
     }
 
     async function generateContentHandler() {

--- a/final_schema.sql
+++ b/final_schema.sql
@@ -19,6 +19,7 @@ CREATE TABLE public.courses (
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     title text NOT NULL,
     description text NULL,
+    presentation_url text NULL,
     content jsonb NULL,
     status text DEFAULT 'draft'::text NOT NULL, -- 'draft', 'published', 'archived'
     draft_content jsonb NULL, -- Для автосохранения черновиков

--- a/index.html
+++ b/index.html
@@ -925,12 +925,36 @@
                 updateSliderUI();
                 return { slider, prevBtn, nextBtn };
             };
-            const { slider, prevBtn, nextBtn } = renderPresentationForView(currentCourse.summary);
-            sliderContainer.appendChild(slider);
-            if (prevBtn && nextBtn) {
-                navButtonsContainer.appendChild(prevBtn);
-                navButtonsContainer.appendChild(nextBtn);
+            // NEW: Check if the course is from a Google Slides presentation
+            if (currentCourse.presentation_url) {
+                sliderContainer.innerHTML = ''; // Clear existing content
+                navButtonsContainer.style.display = 'none'; // Hide our custom nav
+
+                const iframe = document.createElement('iframe');
+                // Transform the URL for embedding. Example: /pub? -> /embed?
+                const embedUrl = currentCourse.presentation_url.replace('/pub?', '/embed?') + '&amp;start=false&amp;loop=false&amp;delayms=3000&amp;rm=minimal';
+
+                iframe.src = embedUrl;
+                iframe.style.width = '100%';
+                iframe.style.height = '100%';
+                iframe.style.border = 'none';
+                iframe.allow = "fullscreen";
+
+                sliderContainer.appendChild(iframe);
+            } else {
+                // Original logic for generated slides
+                navButtonsContainer.style.display = 'flex'; // Ensure nav is visible
+                const { slider, prevBtn, nextBtn } = renderPresentationForView(currentCourse.summary);
+                sliderContainer.innerHTML = ''; // Clear before appending
+                sliderContainer.appendChild(slider);
+
+                navButtonsContainer.innerHTML = ''; // Clear before appending
+                if (prevBtn && nextBtn) {
+                    navButtonsContainer.appendChild(prevBtn);
+                    navButtonsContainer.appendChild(nextBtn);
+                }
             }
+
             rightContent.appendChild(sliderContainer);
             rightContent.appendChild(navButtonsContainer);
             container.appendChild(leftSidebar);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@supabase/supabase-js": "^2.57.2",
         "axios": "^1.11.0",
         "c8": "^10.1.3",
+        "cheerio": "^1.0.0-rc.12",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
@@ -772,6 +773,12 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -976,6 +983,48 @@
         "node": "*"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.12.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -1155,6 +1204,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/css-tree": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
@@ -1166,6 +1231,18 @@
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssstyle": {
@@ -1370,6 +1447,73 @@
       "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -1430,6 +1574,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/entities": {
@@ -2052,6 +2221,25 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -17740,6 +17928,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -17886,6 +18086,31 @@
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -18846,6 +19071,15 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
       "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.10.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@google/generative-ai": "^0.24.1",
     "@supabase/supabase-js": "^2.57.2",
     "axios": "^1.11.0",
+    "cheerio": "^1.0.0-rc.12",
     "c8": "^10.1.3",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",

--- a/server/controllers/adminController.js
+++ b/server/controllers/adminController.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto');
 const axios = require('axios');
 const { createSupabaseAdminClient } = require('../lib/supabaseClient');
-const { handleUploadAndProcess, handleGenerateContent, handleGenerateSummary } = require('../services/backgroundJobs');
+const { handlePresentationProcessing, handleUploadAndProcess, handleGenerateContent, handleGenerateSummary } = require('../services/backgroundJobs');
 const { ACTIONS } = require('../../shared/constants');
 
 // --- Service URLs ---
@@ -94,6 +94,36 @@ const adminActionHandlers = {
         handleUploadAndProcess(jobId, payload, token).catch(console.error);
         res.status(202).json({ jobId });
         return null;
+    },
+    [ACTIONS.PROCESS_PRESENTATION]: async ({ payload, res }) => {
+        const { course_id, presentation_url } = payload;
+        if (!course_id || !presentation_url) {
+            throw { status: 400, message: 'course_id and presentation_url are required.' };
+        }
+
+        const supabaseAdmin = createSupabaseAdminClient();
+
+        // First, save the URL to the course table
+        const { error: updateError } = await supabaseAdmin
+            .from('courses')
+            .update({ presentation_url })
+            .eq('id', course_id);
+
+        if (updateError) {
+            throw { status: 500, message: `Failed to save presentation URL: ${updateError.message}` };
+        }
+
+        // Then, start the background job
+        const jobId = crypto.randomUUID();
+        await supabaseAdmin.from('background_jobs').insert({
+            id: jobId,
+            job_type: 'presentation_processing',
+            status: 'pending',
+            payload
+        });
+        handlePresentationProcessing(jobId, payload).catch(console.error);
+        res.status(202).json({ jobId });
+        return null; // Important: prevent double response
     },
     [ACTIONS.GENERATE_CONTENT]: async ({ payload, token, res }) => {
         const jobId = crypto.randomUUID();

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -11,6 +11,7 @@ const ACTIONS = {
 
     // Content Generation
     UPLOAD_AND_PROCESS: 'upload_and_process',
+    PROCESS_PRESENTATION: 'process_presentation',
     GENERATE_CONTENT: 'generate_content',
     GENERATE_SUMMARY: 'generate_summary',
 


### PR DESCRIPTION
This feature adds a new workflow for creating courses by providing a public Google Slides presentation link.

Key changes:
- **Backend**:
  - Added `presentation_url` to the `courses` table in the database schema.
  - Implemented a new background job `handlePresentationProcessing` to fetch the Google Slides HTML, parse it with Cheerio, and extract the text content.
  - The extracted text is saved to the course's `description`.
  - Modified the `handleGenerateContent` job to support a `questions_only` mode, which generates only test questions from the description, leaving the course summary (slides) empty.
  - Added a `PROCESS_PRESENTATION` API endpoint in the admin controller to manage this new flow.

- **Frontend (Admin)**:
  - Added a new section to the course creation form allowing admins to input a Google Slides URL.
  - Implemented the client-side logic to call the new API endpoint and handle the asynchronous job processing.

- **Frontend (Client)**:
  - Updated the course viewing page to check for the `presentation_url`.
  - If the URL is present, it now embeds the Google Slides presentation in an `<iframe>` instead of rendering the custom slides.
  - The custom slide navigation is hidden for presentation-based courses.