### PR TITLE
feat: Replace file uploads with external URLs for course materials

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -724,10 +724,13 @@
             content = '';
         }
 
-        let materialsHtml = 'Материалы не загружены.';
+        let materialsHtml = 'Материалы не добавлены.';
         if (isEditing && course.course_materials && course.course_materials.length > 0) {
             materialsHtml = course.course_materials.map(mat =>
-                `<div>${escapeHTML(mat.file_name)} <button class="delete-material-btn" data-id="${mat.id}" data-path="${mat.storage_path}">Удалить</button></div>`
+                `<div style="display: flex; align-items: center; justify-content: space-between; padding: 5px; border-bottom: 1px solid #eee;">
+                <a href="${escapeHTML(mat.file_url)}" target="_blank">${escapeHTML(mat.file_name)}</a>
+                <button class="delete-material-btn" data-id="${mat.id}" style="width: auto; padding: 2px 8px; font-size: 12px; background-color: #dc3545;">Удалить</button>
+            </div>`
             ).join('');
         }
 
@@ -770,10 +773,13 @@
                 </div>
                 <button id="cancel-edit-btn" style="background-color: #6c757d; margin-top: 10px;">Отмена</button>
                 <hr>
-                <h3>Сопутствующие материалы</h3>
-                <div id="materials-list">${materialsHtml}</div>
-                <input type="file" id="material-uploader">
-                <button id="upload-material-btn">Загрузить материал</button>
+<h3>Сопутствующие материалы</h3>
+<div id="materials-list" style="margin-bottom: 15px;">${materialsHtml}</div>
+<div id="add-material-form" style="display: flex; gap: 10px; align-items: center;">
+    <input type="text" id="material-name" placeholder="Название файла" style="flex: 1; margin-bottom: 0;">
+    <input type="url" id="material-url" placeholder="https://example.com/file.pdf" style="flex: 2; margin-bottom: 0;">
+    <button id="add-material-btn" style="width: auto; padding: 10px 15px; margin-bottom: 0;">+</button>
+</div>
             </div>
         `;
     }
@@ -785,7 +791,7 @@
         document.getElementById('generate-btn').addEventListener('click', generateContentHandler);
         document.getElementById('text-to-speech-btn').addEventListener('click', textToSpeechHandler);
         document.getElementById('publish-btn').addEventListener('click', publishCourseHandler);
-        document.getElementById('upload-material-btn').addEventListener('click', uploadMaterialHandler);
+        document.getElementById('add-material-btn').addEventListener('click', addMaterialHandler); // ИЗМЕНЕНО
         document.getElementById('materials-list').addEventListener('click', deleteMaterialHandler);
         document.getElementById('save-draft-btn').addEventListener('click', saveDraftHandler);
     }
@@ -1003,42 +1009,47 @@
         }
     }
 
-    async function uploadMaterialHandler() {
-        const btn = document.getElementById('upload-material-btn');
-        const file = document.getElementById('material-uploader').files[0];
-        if (!currentEditingCourseId || !file) {
-            showStatus('Выберите курс и файл.', 'error');
-            return;
-        }
+async function addMaterialHandler() {
+    const btn = document.getElementById('add-material-btn');
+    const nameInput = document.getElementById('material-name');
+    const urlInput = document.getElementById('material-url');
 
-        btn.disabled = true;
-        const reader = new FileReader();
-        reader.readAsDataURL(file);
-        reader.onload = async () => {
-            try {
-                await apiCall(ACTIONS.UPLOAD_COURSE_MATERIAL, { course_id: currentEditingCourseId, file_name: file.name, file_data: reader.result.split(',')[1] });
-                loadCourseForEditing(currentEditingCourseId);
-            } catch(e) {
-                /* Handled in apiCall */
-            } finally {
-                btn.disabled = false;
-            }
-        };
-        reader.onerror = () => {
-            showToast('Не удалось прочитать файл.', 'error');
-            btn.disabled = false;
-        }
+    const fileName = nameInput.value.trim();
+    const fileUrl = urlInput.value.trim();
+
+    if (!currentEditingCourseId || !fileName || !fileUrl) {
+        showStatus('Выберите курс, введите название и URL.', 'error');
+        return;
     }
+
+    btn.disabled = true;
+    try {
+        await apiCall(ACTIONS.ADD_COURSE_MATERIAL, {
+            course_id: currentEditingCourseId,
+            file_name: fileName,
+            file_url: fileUrl
+        });
+        showToast('Материал добавлен!', 'success');
+        nameInput.value = '';
+        urlInput.value = '';
+        loadCourseForEditing(currentEditingCourseId); // Перезагружаем курс для обновления списка
+    } catch(e) {
+        /* Handled in apiCall */
+    } finally {
+        btn.disabled = false;
+    }
+}
 
     async function deleteMaterialHandler(e) {
         if (e.target.classList.contains('delete-material-btn')) {
             const btn = e.target;
             const materialId = btn.dataset.id;
-            const storagePath = btn.dataset.path;
-            if (confirm(`Удалить материал "${storagePath}"?`)) {
+            // Убрали storage_path
+            if (confirm(`Удалить этот материал?`)) {
                 btn.disabled = true;
                 try {
-                    await apiCall(ACTIONS.DELETE_COURSE_MATERIAL, { material_id: materialId, storage_path: storagePath });
+                    // В payload теперь только material_id
+                    await apiCall(ACTIONS.DELETE_COURSE_MATERIAL, { material_id: materialId });
                     loadCourseForEditing(currentEditingCourseId);
                 } catch(e) {
                     /* Handled */

--- a/final_schema.sql
+++ b/final_schema.sql
@@ -31,8 +31,7 @@ CREATE TABLE public.course_materials (
     course_id uuid NOT NULL REFERENCES public.courses(id) ON DELETE CASCADE,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     file_name text NOT NULL,
-    storage_path text NOT NULL,
-    public_url text NULL
+    file_url text NULL -- ИЗМЕНЕНО: Раньше было storage_path и public_url
 );
 
 CREATE TABLE public.user_progress (

--- a/index.html
+++ b/index.html
@@ -849,6 +849,38 @@
                 currentCourse.questions = data.questions;
                 currentCourse.materials = data.materials;
             }
+
+            // ... (весь существующий код функции)
+
+            const rightContent = document.querySelector('.presentation-view-right-content');
+            if (rightContent && currentCourse.materials && currentCourse.materials.length > 0) {
+                const materialsContainer = document.createElement('div');
+                materialsContainer.className = 'course-materials-container';
+                materialsContainer.style.marginTop = '20px';
+                materialsContainer.style.paddingTop = '20px';
+                materialsContainer.style.borderTop = '1px solid #eee';
+
+                let materialsHtml = '<h3>Файлы для скачивания по курсу:</h3><ul style="list-style-type: none; padding-left: 0;">';
+                currentCourse.materials.forEach(material => {
+                    materialsHtml += `
+                        <li style="margin-bottom: 10px;">
+                            <a href="${escapeHTML(material.file_url)}" target="_blank" rel="noopener noreferrer" class="btn" style="text-decoration: none; display: inline-block; background-color: #00AEEF;">
+                                📄 ${escapeHTML(material.file_name)}
+                            </a>
+                        </li>
+                    `;
+                });
+                materialsHtml += '</ul>';
+                materialsContainer.innerHTML = materialsHtml;
+
+                // Добавляем блок с материалами после слайдера
+                const sliderNav = rightContent.querySelector('.slider-nav-buttons');
+                if (sliderNav) {
+                    rightContent.insertBefore(materialsContainer, sliderNav);
+                } else {
+                    rightContent.appendChild(materialsContainer);
+                }
+            }
             appView.classList.add('presentation-mode-active');
             productContent.innerHTML = '';
             const container = document.createElement('div');

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -30,7 +30,7 @@ const ACTIONS = {
     ASSIGN_COURSE_TO_USER: 'assign_course_to_user',
 
     // Material Actions
-    UPLOAD_COURSE_MATERIAL: 'upload_course_material',
+    ADD_COURSE_MATERIAL: 'add_course_material', // ИЗМЕНЕНО: Раньше было UPLOAD_COURSE_MATERIAL
     DELETE_COURSE_MATERIAL: 'delete_course_material',
 
     // Settings & Results


### PR DESCRIPTION
This commit refactors the course materials functionality to use external URLs instead of direct file uploads.

Key changes:
- Database schema (`final_schema.sql`): The `course_materials` table is updated to store a `file_url` instead of a `storage_path`.
- Backend (`adminController.js`): The API handlers for adding and deleting materials are modified to work with URLs, removing the logic for file storage operations.
- Admin Panel (`admin.html`): The file upload form is replaced with inputs for a material name and URL. The JavaScript is updated to handle the new workflow.
- User View (`index.html`): A new section is added to the course presentation view to display the list of materials as clickable links for users.