### PR TITLE
fix: Correct JavaScript error in presentation view

### DIFF
--- a/index.html
+++ b/index.html
@@ -849,38 +849,6 @@
                 currentCourse.questions = data.questions;
                 currentCourse.materials = data.materials;
             }
-
-            // ... (весь существующий код функции)
-
-            const rightContent = document.querySelector('.presentation-view-right-content');
-            if (rightContent && currentCourse.materials && currentCourse.materials.length > 0) {
-                const materialsContainer = document.createElement('div');
-                materialsContainer.className = 'course-materials-container';
-                materialsContainer.style.marginTop = '20px';
-                materialsContainer.style.paddingTop = '20px';
-                materialsContainer.style.borderTop = '1px solid #eee';
-
-                let materialsHtml = '<h3>Файлы для скачивания по курсу:</h3><ul style="list-style-type: none; padding-left: 0;">';
-                currentCourse.materials.forEach(material => {
-                    materialsHtml += `
-                        <li style="margin-bottom: 10px;">
-                            <a href="${escapeHTML(material.file_url)}" target="_blank" rel="noopener noreferrer" class="btn" style="text-decoration: none; display: inline-block; background-color: #00AEEF;">
-                                📄 ${escapeHTML(material.file_name)}
-                            </a>
-                        </li>
-                    `;
-                });
-                materialsHtml += '</ul>';
-                materialsContainer.innerHTML = materialsHtml;
-
-                // Добавляем блок с материалами после слайдера
-                const sliderNav = rightContent.querySelector('.slider-nav-buttons');
-                if (sliderNav) {
-                    rightContent.insertBefore(materialsContainer, sliderNav);
-                } else {
-                    rightContent.appendChild(materialsContainer);
-                }
-            }
             appView.classList.add('presentation-mode-active');
             productContent.innerHTML = '';
             const container = document.createElement('div');
@@ -992,6 +960,35 @@
             container.appendChild(leftSidebar);
             container.appendChild(rightContent);
             productContent.appendChild(container);
+
+            if (rightContent && currentCourse.materials && currentCourse.materials.length > 0) {
+                const materialsContainer = document.createElement('div');
+                materialsContainer.className = 'course-materials-container';
+                materialsContainer.style.marginTop = '20px';
+                materialsContainer.style.paddingTop = '20px';
+                materialsContainer.style.borderTop = '1px solid #eee';
+
+                let materialsHtml = '<h3>Файлы для скачивания по курсу:</h3><ul style="list-style-type: none; padding-left: 0;">';
+                currentCourse.materials.forEach(material => {
+                    materialsHtml += `
+                        <li style="margin-bottom: 10px;">
+                            <a href="${escapeHTML(material.file_url)}" target="_blank" rel="noopener noreferrer" class="btn" style="text-decoration: none; display: inline-block; background-color: #00AEEF;">
+                                📄 ${escapeHTML(material.file_name)}
+                            </a>
+                        </li>
+                    `;
+                });
+                materialsHtml += '</ul>';
+                materialsContainer.innerHTML = materialsHtml;
+
+                const sliderNav = rightContent.querySelector('.slider-nav-buttons');
+                if (sliderNav) {
+                    rightContent.insertBefore(materialsContainer, sliderNav);
+                } else {
+                    rightContent.appendChild(materialsContainer);
+                }
+            }
+
             document.getElementById('chat-form-sidebar').addEventListener('submit', handleChatSubmit);
             const chatBoxSidebar = document.getElementById('chat-box-sidebar');
             const savedChat = sessionStorage.getItem(`chatHistory_${currentCourse.id}`);


### PR DESCRIPTION
This commit fixes a "SyntaxError: Identifier has already been declared" bug in `index.html`.

The error was caused by incorrectly adding the course materials display logic at the top of the `try` block in the `showPresentationView` function, which led to a variable being redeclared.

The fix involves:
- Removing the faulty code block.
- Adding the corrected logic to the end of the `try` block, ensuring it runs after all necessary elements are created and using the existing variable scope correctly.