### PR TITLE
fix: Ensure presentation URL is fetched and transformed correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -931,8 +931,8 @@
                 navButtonsContainer.style.display = 'none'; // Hide our custom nav
 
                 const iframe = document.createElement('iframe');
-                // Transform the URL for embedding. Example: /pub? -> /embed?
-                const embedUrl = currentCourse.presentation_url.replace('/pub?', '/embed?') + '&amp;start=false&amp;loop=false&amp;delayms=3000&amp;rm=minimal';
+                // Rebuild the URL to ensure it's always a valid embed link, handling various /pub formats
+                const embedUrl = currentCourse.presentation_url.split('/pub')[0] + '/embed?rm=minimal&amp;start=false&amp;loop=false&amp;delayms=3000';
 
                 iframe.src = embedUrl;
                 iframe.style.width = '100%';

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -121,7 +121,7 @@ const getCourses = async (req, res) => {
         const { data: coursesWithGroups, error: coursesError } = await supabase
             .from('courses')
             .select(`
-                id, title, description,
+                id, title, description, presentation_url,
                 course_group_items (order_index, course_groups (id, group_name, enforce_order))
             `)
             .in('id', allCourseIds)


### PR DESCRIPTION
This commit addresses two issues that prevented embedded Google Slides presentations from displaying:

1.  **Backend Query:** The `/api/getCourses` endpoint was not selecting the `presentation_url` column from the database. The `select` statement in `userController.js` has been updated to include it.

2.  **Frontend URL Transformation:** The logic in `index.html` to convert a `/pub` link to an `/embed` link was not robust. It failed for URLs that did not contain a query string. The logic has been replaced with a more reliable method that splits the URL at `/pub` and rebuilds it as a valid embed link.