### PR TITLE
Fix: Use config.env for environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ web_modules/
 .env.development.local
 .env.test.local
 .env.production.local
+config.env
 
 # Netlify local dev
 .netlify

--- a/config.env
+++ b/config.env
@@ -1,0 +1,3 @@
+# Please replace the placeholder below with your actual Gemini API key.
+# Do not commit this file with your actual key to version control.
+GEMINI_API_KEY=YOUR_API_KEY_HERE

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,6 @@
 // --- CONFIGURATION AND SETUP ---
 const path = require('path');
-require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
+require('dotenv').config({ path: path.join(__dirname, '..', 'config.env') });
 
 const express = require('express');
 const cors = require('cors');


### PR DESCRIPTION
The application was failing to connect to the AI service because the `GEMINI_API_KEY` was not configured. This was due to an issue with creating or modifying the `.env` file in the execution environment.

This change implements a workaround suggested by the user:
- A new file, `config.env`, is used to store environment variables.
- The server is updated to load its configuration from `config.env`.
- The `config.env` file is added to `.gitignore` to prevent committing secrets.
- The `config.env` file includes a placeholder for the API key.

This resolves the "AI service is currently unavailable" error by allowing the application to be correctly configured with the necessary API key.