### PR TITLE
fix: Prevent token limit error in presentation processing

### DIFF
--- a/server/services/backgroundJobs.js
+++ b/server/services/backgroundJobs.js
@@ -33,6 +33,11 @@ async function handlePresentationProcessing(jobId, payload) {
 
         // 2. Extract text using Cheerio
         const $ = cheerio.load(html);
+
+        // --- NEW: Remove code blocks before extracting text ---
+        // This targets common tags for code snippets to reduce token count for the AI.
+        $('pre, code').remove();
+
         // This selector is now more robust, taking all text from the body to avoid issues with Google's class name changes.
         const textContent = $('body').text().replace(/\s+/g, ' ').trim();
 


### PR DESCRIPTION
The text extraction from Google Slides presentations was including code blocks, which could lead to a very large text content. This was causing the Gemini API to return a "token limit exceeded" error when generating test questions.

This change modifies the text extraction logic to remove common HTML tags for code (`<pre>` and `<code>`) before extracting the text content. This significantly reduces the size of the text sent to the AI, preventing the error and ensuring that only relevant content is used for question generation.