### PR TITLE
fix: Strip all code and scripts from presentation text

### DIFF
--- a/server/services/backgroundJobs.js
+++ b/server/services/backgroundJobs.js
@@ -34,9 +34,9 @@ async function handlePresentationProcessing(jobId, payload) {
         // 2. Extract text using Cheerio
         const $ = cheerio.load(html);
 
-        // --- NEW: Remove code blocks before extracting text ---
-        // This targets common tags for code snippets to reduce token count for the AI.
-        $('pre, code').remove();
+        // --- NEW: Remove code and script blocks before extracting text ---
+        // This targets common tags for code, scripts, and styles to reduce token count for the AI.
+        $('pre, code, script, style').remove();
 
         // This selector is now more robust, taking all text from the body to avoid issues with Google's class name changes.
         const textContent = $('body').text().replace(/\s+/g, ' ').trim();


### PR DESCRIPTION
The previous fix for the token limit error was incomplete. It only removed `<pre>` and `<code>` tags, but Google Slides presentations also include `<script>` and `<style>` tags with a lot of content that is not relevant for the AI.

This change enhances the text extraction logic to also remove `<script>` and `<style>` tags. This provides a much more robust solution that should prevent the 'token limit exceeded' error by ensuring only the actual text content of the presentation is sent to the AI for question generation.