### PR TITLE
Fix(assistant): Handle inconsistent content structure

### DIFF
--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -316,9 +316,9 @@ const askAssistant = async (req, res) => {
         if (courseError || !courseData) return res.status(404).json({ error: 'Course not found.' });
 
         let courseTextContent = '';
-        if (courseData.content && typeof courseData.content === 'object' && courseData.content.summary) {
+        if (courseData.content && typeof courseData.content === 'object' && courseData.content.summary && Array.isArray(courseData.content.summary.slides)) {
             // Extract text from presentation slides
-            courseTextContent = courseData.content.summary.map(slide => {
+            courseTextContent = courseData.content.summary.slides.map(slide => {
                 const slideTitle = slide.slide_title || '';
                 const slideContent = slide.html_content || '';
                 // Basic HTML tag stripping and combine title + content


### PR DESCRIPTION
The `askAssistant` function would crash with a `TypeError` when processing a course whose `content` JSON field did not have a `summary` property containing an array.

This was caused by the code directly calling `.map()` on `course.content.summary` instead of the nested `course.content.summary.slides` array.

This patch fixes the issue by:
1. Accessing the correct nested `slides` array.
2. Adding an `Array.isArray()` check to ensure the code is robust against different data shapes.

This aligns the data handling logic with the `getCourseContent` function, making it more consistent and preventing future crashes.