### PR TITLE
Fix: Ensure catalog displays all published courses

### DIFF
--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -283,8 +283,7 @@ const getCourseCatalog = async (req, res) => {
         const { data: allCatalogCourses, error: coursesError } = await supabase
             .from('courses')
             .select(`id, title, description, course_group_items(course_groups(group_name))`)
-            .eq('status', 'published')
-            .eq('is_visible', true);
+            .eq('status', 'published');
 
         if (coursesError) throw coursesError;
 


### PR DESCRIPTION
Updates the `getCourseCatalog` controller to remove the `is_visible` filter. This ensures that all courses with a 'published' status appear in the catalog, even if they are marked as not visible.

This change addresses an issue where a completed course was not appearing in the catalog, providing a more complete and consistent view of all available courses to the user.