### PR TITLE
feat: Add technical link for public course viewing

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -930,9 +930,24 @@
             ).join('');
         }
 
+        let techLinkHtml = '';
+        if (isEditing && course.latest_generation) {
+            const link = `${window.location.origin}/public_course.html?key=${course.latest_generation.access_key}`;
+            const genDate = new Date(course.latest_generation.generated_at).toLocaleString('ru-RU');
+            techLinkHtml = `
+                <div id="tech-link-info" style="background-color: #e9f7fe; padding: 15px; border-radius: 8px; margin-bottom: 20px;">
+                    <h4><i class="fa-solid fa-link"></i> Техническая ссылка (для просмотра)</h4>
+                    <p style="font-size: 0.9em; color: #666; margin-top: -5px;">Эта ссылка позволяет просмотреть материалы курса без входа в систему. Она обновляется каждый раз при полной генерации контента.</p>
+                    <input type="text" readonly value="${link}" style="background-color: #fff; cursor: pointer;" onclick="this.select(); document.execCommand('copy'); showToast('Ссылка скопирована!', 'success');">
+                    <p style="font-size: 0.9em; color: #333;">Последняя генерация: <b>${genDate}</b></p>
+                </div>
+            `;
+        }
+
         return `
             <div id="course-form-container">
                 <h2>${headerText}</h2>
+                ${techLinkHtml}
                 <input type="hidden" id="course-id" value="${escapeHTML(courseId)}">
                 <input type="text" id="course-title" placeholder="Название курса" value="${escapeHTML(title)}">
                 <h3>Шаг 1А: Генерация из файла (текущий функционал)</h3>

--- a/final_schema.sql
+++ b/final_schema.sql
@@ -110,6 +110,16 @@ CREATE TABLE public.group_assignments (
     CONSTRAINT unique_department_assignment UNIQUE (group_id, department)
 );
 
+CREATE TABLE public.course_generations (
+    id uuid DEFAULT gen_random_uuid() NOT NULL PRIMARY KEY,
+    course_id uuid NOT NULL REFERENCES public.courses(id) ON DELETE CASCADE,
+    generated_at timestamp with time zone DEFAULT now() NOT NULL,
+    access_key text NOT NULL UNIQUE
+);
+CREATE INDEX idx_course_generations_access_key ON public.course_generations(access_key);
+COMMENT ON TABLE public.course_generations IS 'Stores a record of each course content generation event, providing a unique key for technical access.';
+
+
 -- ===========
 -- # ФУНКЦИИ #
 -- ===========
@@ -253,6 +263,7 @@ ALTER TABLE public.simulation_results ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.course_groups ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.course_group_items ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.group_assignments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.course_generations ENABLE ROW LEVEL SECURITY;
 
 -- ОБНОВЛЕННЫЕ ПОЛИТИКИ
 CREATE POLICY "Enable read access for user on their own user record" ON public.users FOR SELECT USING (auth.uid() = id);
@@ -273,6 +284,9 @@ CREATE POLICY "Admins have full access to simulation_results" ON public.simulati
 CREATE POLICY "Admins have full access to course groups" ON public.course_groups FOR ALL USING (public.is_claims_admin());
 CREATE POLICY "Admins have full access to course group items" ON public.course_group_items FOR ALL USING (public.is_claims_admin());
 CREATE POLICY "Admins have full access to group assignments" ON public.group_assignments FOR ALL USING (public.is_claims_admin());
+CREATE POLICY "Admins have full access to course generations" ON public.course_generations FOR ALL USING (public.is_claims_admin());
+CREATE POLICY "Enable public read access for course generations" ON public.course_generations FOR SELECT USING (true);
+
 
 -- Политики для аутентифицированных пользователей остаются без изменений
 CREATE POLICY "Authenticated users can read visible course groups" ON public.course_groups FOR SELECT USING (auth.role() = 'authenticated' AND is_visible = true);

--- a/public_course.html
+++ b/public_course.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <title>Просмотр курса</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
+    <style>
+        :root {
+            --primary-color: #005A9C;
+            --bg-color: #f4f7f6;
+            --surface-color: #ffffff;
+            --text-color: #333333;
+            --border-color: #e0e0e0;
+        }
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; padding: 20px; max-width: 900px; margin: auto; background-color: var(--bg-color); color: var(--text-color); }
+        h1, h2, h3 { color: var(--primary-color); }
+        #course-container { background-color: var(--surface-color); padding: 25px; border-radius: 8px; box-shadow: 0 4px 15px rgba(0,0,0,0.08); }
+        .slide { border: 1px solid var(--border-color); padding: 15px; margin-bottom: 20px; border-radius: 5px; }
+        .slide-title { font-size: 1.5em; font-weight: bold; margin-bottom: 10px; border-bottom: 2px solid var(--primary-color); padding-bottom: 10px; color: var(--primary-color); }
+        .question { background-color: #f1f3f5; padding: 15px; margin-top: 15px; border-radius: 5px; border-left: 4px solid var(--primary-color); }
+        .options { list-style-type: none; padding-left: 0; }
+        .option { margin-bottom: 8px; }
+        .materials-list { list-style-type: none; padding: 0; margin-top: 20px; }
+        .materials-list li { margin-bottom: 10px; }
+        .materials-list a { text-decoration: none; color: var(--primary-color); font-weight: bold; }
+        .loading, .error { text-align: center; font-size: 1.2em; padding: 40px; }
+    </style>
+</head>
+<body>
+    <div id="course-container">
+        <h1 id="course-title" class="loading">Загрузка курса...</h1>
+        <div id="course-content"></div>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', async () => {
+            const container = document.getElementById('course-content');
+            const titleElement = document.getElementById('course-title');
+            const params = new URLSearchParams(window.location.search);
+            const accessKey = params.get('key');
+
+            if (!accessKey) {
+                titleElement.textContent = 'Ошибка';
+                container.innerHTML = '<p class="error">Ключ доступа не найден в ссылке.</p>';
+                return;
+            }
+
+            try {
+                const response = await fetch(`/api/public/course/${accessKey}`);
+                if (!response.ok) {
+                    const errorData = await response.json();
+                    throw new Error(errorData.error || `Ошибка ${response.status}`);
+                }
+                const course = await response.json();
+
+                titleElement.textContent = course.title || 'Курс без названия';
+
+                let contentHtml = '<h2>Презентация</h2>';
+                if (course.summary && course.summary.length > 0) {
+                    course.summary.forEach(slide => {
+                        contentHtml += `
+                            <div class="slide">
+                                <div class="slide-title">${slide.slide_title || ''}</div>
+                                <div class="slide-content">${slide.html_content || ''}</div>
+                                ${slide.image_url ? `<img src="${slide.image_url}" alt="Slide Image" style="max-width: 100%; height: auto; margin-top: 10px; border-radius: 4px;">` : ''}
+                            </div>
+                        `;
+                    });
+                } else {
+                    contentHtml += '<p>Слайды для этого курса не найдены.</p>';
+                }
+
+                contentHtml += '<h2>Тестовые вопросы</h2>';
+                if (course.questions && course.questions.length > 0) {
+                    course.questions.forEach(q => {
+                        contentHtml += `
+                            <div class="question">
+                                <strong>Вопрос:</strong> ${q.question || ''}
+                                <ul class="options">
+                                    ${(q.options || []).map((opt, i) => `<li class="option">${i === q.correct_option_index ? '<b>✅ ' : '⬜️ '}${opt}${i === q.correct_option_index ? '</b>' : ''}</li>`).join('')}
+                                </ul>
+                            </div>
+                        `;
+                    });
+                } else {
+                    contentHtml += '<p>Тестовые вопросы для этого курса не найдены.</p>';
+                }
+
+                if (course.materials && course.materials.length > 0) {
+                    contentHtml += '<h2>Сопутствующие материалы</h2>';
+                    contentHtml += '<ul class="materials-list">';
+                    course.materials.forEach(mat => {
+                        contentHtml += `<li><a href="${mat.file_url}" target="_blank" rel="noopener noreferrer">${mat.file_name}</a></li>`;
+                    });
+                    contentHtml += '</ul>';
+                }
+
+                container.innerHTML = contentHtml;
+
+            } catch (error) {
+                titleElement.textContent = 'Не удалось загрузить курс';
+                container.innerHTML = `<p class="error">${error.message}</p>`;
+                console.error('Fetch course error:', error);
+            }
+        });
+    </script>
+</body>
+</html>

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -13,6 +13,9 @@ apiRouter.post('/admin', adminAuthMiddleware, handleAdminAction);
 // The detailed report also requires admin privileges.
 apiRouter.post('/getDetailedReport', adminAuthMiddleware, getDetailedReport);
 
+// --- Public Routes (No Auth Required) ---
+apiRouter.get('/public/course/:access_key', userController.getPublicCourseByAccessKey);
+
 
 // --- User-facing Authenticated Routes ---
 // All routes below this middleware will require a valid user token.


### PR DESCRIPTION
Implements a feature to generate a non-authenticated 'technical link' for courses. This allows users with the link to view course materials without logging in.

- **DB:** Adds a `course_generations` table to store a unique `access_key` and timestamp for each course content generation event. Includes appropriate RLS policies for admin and public access.
- **Backend:**
    - Modifies the content generation background job to create a record in `course_generations` upon successful completion.
    - Adds a new public API endpoint `GET /api/public/course/:access_key` to serve course content.
    - Updates the admin `GET_COURSE_DETAILS` endpoint to include the latest generation link and timestamp.
- **Frontend:**
    - Creates a new `public_course.html` page to render read-only course content fetched via the public API.
    - Updates the admin panel to display the technical link and last generation time in the course editor.