### PR TITLE
Fix(api): Handle get_job_status action in admin controller

### DIFF
--- a/server/controllers/adminController.js
+++ b/server/controllers/adminController.js
@@ -21,6 +21,14 @@ const adminActionHandlers = {
         if (error) throw error;
         return data;
     },
+    [ACTIONS.GET_JOB_STATUS]: async ({ payload, supabaseAdmin }) => {
+        const { jobId } = payload;
+        if (!jobId) throw { status: 400, message: 'A jobId is required.' };
+        const { data, error } = await supabaseAdmin.from('background_jobs').select('*').eq('id', jobId).single();
+        if (error) throw error;
+        if (!data) throw { status: 404, message: 'Job not found.' };
+        return data;
+    },
     [ACTIONS.GET_COURSES_ADMIN]: async ({ supabaseAdmin }) => {
         // Fetch courses and their associated group name through the join table
         const { data, error } = await supabaseAdmin

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -40,6 +40,7 @@ const ACTIONS = {
 
     // Misc Actions
     TEXT_TO_SPEECH: 'text_to_speech',
+    GET_JOB_STATUS: 'get_job_status',
 };
 
 // Check if we are in a Node.js environment

--- a/test/server/api.test.js
+++ b/test/server/api.test.js
@@ -82,16 +82,15 @@ describe('API Endpoints', () => {
         sinon.restore();
     });
 
-    describe('POST /api/get-job-status', () => {
+    describe('POST /api/admin with action get_job_status', () => {
         it('should return job status if job is found', async () => {
             const fakeJob = { id: 'some-job-id', status: 'completed' };
-            // The admin client is used for job status, so we mock its call chain
             supabaseStub.single.resolves({ data: fakeJob, error: null });
 
             const response = await request(app)
-                .post('/api/get-job-status')
-                .set('Authorization', 'Bearer mock-token') // Pass auth middleware
-                .send({ jobId: 'some-job-id' });
+                .post('/api/admin')
+                .set('Authorization', 'Bearer mock-admin-token')
+                .send({ action: 'get_job_status', jobId: 'some-job-id' });
 
             expect(response.status).to.equal(200);
             expect(response.body).to.deep.equal(fakeJob);
@@ -100,21 +99,21 @@ describe('API Endpoints', () => {
         });
 
         it('should return 404 if job is not found', async () => {
-            supabaseStub.single.resolves({ data: null, error: { message: 'Not found' } });
+            supabaseStub.single.resolves({ data: null, error: null });
 
             const response = await request(app)
-                .post('/api/get-job-status')
-                .set('Authorization', 'Bearer mock-token')
-                .send({ jobId: 'non-existent-job-id' });
+                .post('/api/admin')
+                .set('Authorization', 'Bearer mock-admin-token')
+                .send({ action: 'get_job_status', jobId: 'non-existent-job-id' });
 
             expect(response.status).to.equal(404);
         });
 
         it('should return 400 if jobId is missing', async () => {
             const response = await request(app)
-                .post('/api/get-job-status')
-                .set('Authorization', 'Bearer mock-token')
-                .send({});
+                .post('/api/admin')
+                .set('Authorization', 'Bearer mock-admin-token')
+                .send({ action: 'get_job_status' });
 
             expect(response.status).to.equal(400);
         });
@@ -123,9 +122,9 @@ describe('API Endpoints', () => {
             supabaseStub.single.rejects(new Error('Internal DB Error'));
 
             const response = await request(app)
-                .post('/api/get-job-status')
-                .set('Authorization', 'Bearer mock-token')
-                .send({ jobId: 'some-job-id' });
+                .post('/api/admin')
+                .set('Authorization', 'Bearer mock-admin-token')
+                .send({ action: 'get_job_status', jobId: 'some-job-id' });
 
             expect(response.status).to.equal(500);
         });


### PR DESCRIPTION
The `startJobPolling` function in `admin.html` was making an API call with a `get_job_status` action that was not defined in the backend. This resulted in a "400 Bad Request" with an "Unknown action: undefined" error.

This commit resolves the issue by:
1.  Adding the `GET_JOB_STATUS` constant to `shared/constants.js`.
2.  Implementing a handler for the `get_job_status` action in the `adminController`.
3.  Updating the server-side tests to correctly test the new action through the `/api/admin` endpoint.