### PR TITLE
fix: Correct PDF export and remove public course page

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1219,6 +1219,10 @@
             const { jsPDF } = window.jspdf;
             const contentElement = document.getElementById('wysiwyg-editor');
 
+            // Temporarily expand the element to its full scroll height
+            const originalHeight = contentElement.style.height;
+            contentElement.style.height = `${contentElement.scrollHeight}px`;
+
             html2canvas(contentElement, {
                 scale: 2,
                 useCORS: true,
@@ -1230,6 +1234,8 @@
                     document.head.appendChild(robotoFont);
                 }
             }).then(canvas => {
+                // Restore original height
+                contentElement.style.height = originalHeight;
                 const imgData = canvas.toDataURL('image/png');
                 const pdf = new jsPDF({
                     orientation: 'p',


### PR DESCRIPTION
This commit addresses two issues:
1.  The PDF export functionality was producing garbled text (hieroglyphs) and was not including images or the full content. This has been fixed by using `html2canvas` to render the course content as an image before inserting it into the PDF, and by ensuring the full content is visible before capture.
2.  The public course page (`public_course.html`) has been removed, and the PDF download functionality has been moved to the admin panel, as requested by the user.

Changes include:
- Modified `admin.html` to include `html2canvas` and a new PDF generation logic that correctly renders Cyrillic characters, images, and the full content.
- Removed `public_course.html` and its associated backend logic.
- Added a `db_cleanup.sql` script to remove the now-unused `course_generations` table.